### PR TITLE
fix issue pancakeswap auto amount

### DIFF
--- a/src/platforms/pancake/pancake.js
+++ b/src/platforms/pancake/pancake.js
@@ -399,9 +399,14 @@ module.exports = class pancake {
           ? 10 ** this.tokenCollector.getDecimals(farm.extra.transactionToken)
           : 1e18;
 
+        var pos = 0  
+        if(farm.id.startsWith('pancake_auto') && c.userInfo[2]){
+          pos = 2
+        }
+
         result.deposit = {
           symbol: farm.symbol,
-          amount: call.userInfo[0] / decimals
+          amount: call.userInfo[pos] / decimals
         };
 
         let address1 = this.getAddress(farm.extra.transactionToken);

--- a/src/platforms/pancake/pancake.js
+++ b/src/platforms/pancake/pancake.js
@@ -400,7 +400,7 @@ module.exports = class pancake {
           : 1e18;
 
         var pos = 0  
-        if(farm.id.startsWith('pancake_auto') && c.userInfo[2]){
+        if(farm.id.startsWith('pancake_auto') && call.userInfo[2]){
           pos = 2
         }
 


### PR DESCRIPTION
Hello,

first, let me thank you for farm.army.

Now, there is an error in the displayed amount for pancakeswap's cake auto compound pool.

as you can see the API returns the initial deposit without adding the total compounded.

![26 05 2021_18 08 58_REC](https://user-images.githubusercontent.com/5620128/119735972-7c2fc300-be53-11eb-8ff6-257ff62d7c91.png)
![26 05 2021_18 10 21_REC](https://user-images.githubusercontent.com/5620128/119735975-7cc85980-be53-11eb-9857-df38f0bb38aa.png)

the total amount atm is 108 cakes.
![26 05 2021_18 08 34_REC](https://user-images.githubusercontent.com/5620128/119736107-9ec1dc00-be53-11eb-954c-479e4167671e.png)

I have added a small patch to fix this problem. 
Let me know if this is ok.

thanks!
